### PR TITLE
EPGに取得するチューナー数を指定できるようにした。

### DIFF
--- a/EpgTimer/EpgTimer/DefineClass/TunerInfo.cs
+++ b/EpgTimer/EpgTimer/DefineClass/TunerInfo.cs
@@ -17,6 +17,11 @@ namespace EpgTimer
             get;
             set;
         }
+        public String EPGNum
+        {
+            get;
+            set;
+        }
         public bool IsEpgCap
         {
             get;

--- a/EpgTimer/EpgTimer/Setting/SetBasicView.xaml
+++ b/EpgTimer/EpgTimer/Setting/SetBasicView.xaml
@@ -45,6 +45,7 @@
                     <Label Content="※ 上にあるBonDriverから優先的に使用します" Height="28" HorizontalAlignment="Left" Margin="40,218,0,0" Name="label13" VerticalAlignment="Top" />
                     <Label Content="※ 設定を変更した場合、一度終了してください。次回起動時に設定が有効になります。" Foreground="Red" Height="28" HorizontalAlignment="Left" Margin="12,277,0,0" Name="label14" VerticalAlignment="Top" />
                     <Label Content="※ Windowsサービスとして動作させている場合は、Windowsサービスを一度停止してください。" Foreground="Red" Height="28" HorizontalAlignment="Left" Margin="12,311,0,0" Name="label15" VerticalAlignment="Top" />
+                    <TextBox Height="24" HorizontalAlignment="Left" Margin="579,84,0,0" Name="textBox_bon_epgnum" Text="{Binding Path=EPGNum}" VerticalAlignment="Top" Width="68" />
                 </Grid>
             </TabItem>
             <TabItem Header="EPG取得" Name="tabItem3">

--- a/EpgTimer/EpgTimer/Setting/SetBasicView.xaml.cs
+++ b/EpgTimer/EpgTimer/Setting/SetBasicView.xaml.cs
@@ -101,6 +101,7 @@ namespace EpgTimer.Setting
                         {
                             item.IsEpgCap = true;
                         }
+                        item.EPGNum = IniFileHandler.GetPrivateProfileInt(item.BonDriver, "EPGCount", 0, SettingPath.TimerSrvIniPath).ToString();
                         int priority = IniFileHandler.GetPrivateProfileInt(item.BonDriver, "Priority", 0xFFFF, SettingPath.TimerSrvIniPath);
                         while (true)
                         {
@@ -298,6 +299,7 @@ namespace EpgTimer.Setting
                     {
                         IniFileHandler.WritePrivateProfileString(info.BonDriver, "GetEpg", "0", SettingPath.TimerSrvIniPath);
                     }
+                    IniFileHandler.WritePrivateProfileString(info.BonDriver, "EPGCount", info.EPGNum, SettingPath.TimerSrvIniPath);
                     IniFileHandler.WritePrivateProfileString(info.BonDriver, "Priority", i.ToString(), SettingPath.TimerSrvIniPath);
                 }
 
@@ -618,6 +620,7 @@ namespace EpgTimer.Setting
                     TunerInfo info = listBox_bon.SelectedItem as TunerInfo;
                     textBox_bon_num.DataContext = info;
                     checkBox_bon_epg.DataContext = info;
+                    textBox_bon_epgnum.DataContext = info;
                 }
             }
             catch (Exception ex)

--- a/EpgTimerSrv/EpgTimerSrv/TunerManager.cpp
+++ b/EpgTimerSrv/EpgTimerSrv/TunerManager.cpp
@@ -87,12 +87,18 @@ BOOL CTunerManager::ReloadTuner()
 					//カウント0以上のものだけ利用
 					WORD priority = (WORD)GetPrivateProfileInt(bonFileName.c_str(), L"Priority", 0, srvIniPath.c_str());
 					BOOL epgCapFlag = (BOOL)GetPrivateProfileInt(bonFileName.c_str(), L"GetEpg", 1, srvIniPath.c_str());
+					WORD EPGcount = (WORD)GetPrivateProfileInt(bonFileName.c_str(), L"EPGCount", -1, srvIniPath.c_str());
+					if(EPGcount<0) EPGcount = count;
 
 					for( WORD i=1; i<=count; i++ ){
 						TUNER_INFO* item = new TUNER_INFO;
 						item->bonID = priority;
 						item->tunerID = i;
-						item->epgCapFlag = epgCapFlag;
+						if(EPGcount<i){		//	EPGCountを超えていたらEPG取得に使用しない
+							item->epgCapFlag = 0;
+						} else {
+							item->epgCapFlag = epgCapFlag;
+						}
 						item->bonFileName = bonFileName;
 						item->chUtil.ParseText(chSetPath.c_str());
 						item->chSet4FilePath = chSetPath;


### PR DESCRIPTION
VirtualPT等、１つのDLLで複数のチューナーを操作する場合に、EPGを取得するチューナーに指定すると、EPGを取得中にTvTestでの視聴が出来ない。
EPG取得中でも番組を視聴できるように、EPGの取得に使用しないチューナーを確保するための設定を追加した。
設定なしの場合は全てのチューナーをEPG取得設定に合わせています。
